### PR TITLE
add missing dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "xls-to-json": "^0.5.1"
   },
   "devDependencies": {
+    "ajv": "^6.12.6",
     "electron": "^5.0.13",
     "electron-builder": "^22.4.1",
     "electron-packager": "^13.0.0",


### PR DESCRIPTION
Missing dependency on Ubuntu 20.04.1 LTS.
```electron``` can not be compiled without this.